### PR TITLE
add variant build of hpctoolkit using spack containerize

### DIFF
--- a/.github/workflows/docker-builds.yaml
+++ b/.github/workflows/docker-builds.yaml
@@ -23,6 +23,7 @@ jobs:
                ["quicksilver", "ghcr.io/converged-computing/metric-quicksilver:latest"],
                ["ovis-hpc", "ghcr.io/converged-computing/metric-ovis-hpc:latest"],
                ["kripke", "ghcr.io/converged-computing/metric-kripke:latest"],
+               ["hpctoolkit-containerize", "ghcr.io/converged-computing/metric-hpctoolkit-view:latest"],
                ["hpctoolkit-spack", "ghcr.io/converged-computing/metric-hpctoolkit-spack:latest"],
                ["hpctoolkit", "ghcr.io/converged-computing/metric-hpctoolkit:latest"],
                ["bdas", "ghcr.io/converged-computing/metric-bdas:latest"],

--- a/hpctoolkit-containerize/Dockerfile
+++ b/hpctoolkit-containerize/Dockerfile
@@ -1,0 +1,47 @@
+FROM spack/ubuntu-jammy:latest as builder
+
+# What we want to install and how we want to install it
+# is specified in a manifest file (spack.yaml)
+RUN mkdir /opt/spack-environment \
+&&  (echo spack: \
+&&   echo '  specs: [hpctoolkit]' \
+&&   echo '  view: /opt/views/view' \
+&&   echo '  concretizer:' \
+&&   echo '    unify: true' \
+&&   echo '  config:' \
+&&   echo '    install_tree: /opt/software') > /opt/spack-environment/spack.yaml
+
+# Install the software, remove unnecessary deps
+RUN cd /opt/spack-environment && spack env activate . && spack install --fail-fast && spack gc -y
+
+# Strip all the binaries
+RUN find -L /opt/views/view/* -type f -exec readlink -f '{}' \; | \
+    xargs file -i | \
+    grep 'charset=binary' | \
+    grep 'x-executable\|x-archive\|x-sharedlib' | \
+    awk -F: '{print $1}' | xargs strip
+
+# Modifications to the environment that are necessary to run
+RUN cd /opt/spack-environment && \
+    spack env activate --sh -d . > activate.sh
+
+# Bare OS image to run the installed executables
+FROM ubuntu:22.04
+
+COPY --from=builder /opt/spack-environment /opt/spack-environment
+COPY --from=builder /opt/software /opt/software
+
+# paths.view is a symlink, so copy the parent to avoid dereferencing and duplicating it
+COPY --from=builder /opt/views /opt/views
+
+RUN { \
+      echo '#!/bin/sh' \
+      && echo '.' /opt/spack-environment/activate.sh \
+      && echo 'exec "$@"'; \
+    } > /entrypoint.sh \
+&& chmod a+x /entrypoint.sh \
+&& ln -s /opt/views/view /opt/view
+
+ENTRYPOINT [ "/entrypoint.sh" ]
+CMD [ "/bin/bash" ]
+


### PR DESCRIPTION
This is a second derivative build that uses spack containerize, and creates a copy only view (TBA testing in the metrics operator).